### PR TITLE
「reversi_methods_test.rb」でエラーになっていた箇所を修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
@@ -62,7 +62,7 @@ module ReversiMethods
 
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
-    return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == attack_stone_color || target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)
@@ -86,6 +86,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
## 概要
- ` reversi_methods_test.rb`でエラーになっていた箇所を修正

## 詳細
- `reversi_methods.rb`
  - `put_stone`メソッド
    - 指定された座標に石を置く際、row・colの座標が逆になっているバグを修正
  - `turn`メソッド
    - BLANK_CELLが挟まれていた場合も石が置けてしまうバグを修正
  - `placeable?`メソッド
    - BLANK_CELLが1つもない時にfalseを返すように修正